### PR TITLE
Less GC pressure in job managers

### DIFF
--- a/Runtime/Jobs/Internal/UnsafeNativeList.cs
+++ b/Runtime/Jobs/Internal/UnsafeNativeList.cs
@@ -7,6 +7,7 @@ namespace Gilzoide.UpdateManager.Jobs.Internal
 {
     public unsafe struct UnsafeNativeList<T> : IDisposable where T : struct
     {
+        public const float TrimCapacityThreshold = 0.9f;
         public static readonly long SizeOfT = UnsafeUtility.SizeOf<T>();
         public static readonly int AlignOfT = UnsafeUtility.AlignOf<T>();
 
@@ -113,6 +114,14 @@ namespace Gilzoide.UpdateManager.Jobs.Internal
         {
             EnsureCapacity(other._length, false);
             UnsafeUtility.MemCpy(_buffer, other._buffer, other.BufferLength);
+        }
+
+        public void TrimExcess()
+        {
+            if (_length < _capacity * TrimCapacityThreshold)
+            {
+                Realloc(_length, true);
+            }
         }
     }
 }

--- a/Runtime/Jobs/Internal/UpdateJobData.cs
+++ b/Runtime/Jobs/Internal/UpdateJobData.cs
@@ -1,5 +1,6 @@
 using System;
 using Unity.Collections;
+using UnityEngine;
 
 namespace Gilzoide.UpdateManager.Jobs.Internal
 {
@@ -18,17 +19,18 @@ namespace Gilzoide.UpdateManager.Jobs.Internal
 
         public virtual void EnsureCapacity(int newSize)
         {
-            _data.Realloc(newSize);
+            _data.EnsureCapacity(newSize);
         }
 
         public virtual void Add(TDataProvider dataProvider, int index)
         {
-            _data[index] = dataProvider.InitialJobData;
+            Debug.Assert(_data.Length == index, "FIXME: added index doesn't match data size");
+            _data.Add(dataProvider.InitialJobData);
         }
 
         public virtual void RemoveAtSwapBack(int index)
         {
-            _data.SwapBack(index);
+            _data.RemoveAtSwapBack(index);
         }
 
         public virtual void Dispose()

--- a/Runtime/Jobs/Internal/UpdateJobData.cs
+++ b/Runtime/Jobs/Internal/UpdateJobData.cs
@@ -43,5 +43,11 @@ namespace Gilzoide.UpdateManager.Jobs.Internal
         {
             _backup.CopyFrom(_data);
         }
+
+        public void TrimExcess()
+        {
+            _data.TrimExcess();
+            _backup.TrimExcess();
+        }
     }
 }

--- a/Runtime/Jobs/UpdateJobManager.cs
+++ b/Runtime/Jobs/UpdateJobManager.cs
@@ -22,11 +22,6 @@ namespace Gilzoide.UpdateManager.Jobs
         public static UpdateJobManager<TData> Instance => _instance != null ? _instance : (_instance = new UpdateJobManager<TData>());
         private static UpdateJobManager<TData> _instance;
 
-        static UpdateJobManager()
-        {
-            Application.quitting += () => _instance?.Dispose();
-        }
-
         protected unsafe override JobHandle ScheduleJob(JobHandle dependsOn)
         {
             return new UpdateJob<TData>

--- a/Runtime/Jobs/UpdateTransformJobManager.cs
+++ b/Runtime/Jobs/UpdateTransformJobManager.cs
@@ -25,11 +25,6 @@ namespace Gilzoide.UpdateManager.Jobs
         public static UpdateTransformJobManager<TData> Instance => _instance != null ? _instance : (_instance = new UpdateTransformJobManager<TData>());
         private static UpdateTransformJobManager<TData> _instance;
 
-        static UpdateTransformJobManager()
-        {
-            Application.quitting += () => _instance?.Dispose();
-        }
-
         protected override JobHandle ScheduleJob(JobHandle dependsOn)
         {
             var job = new UpdateTransformJob<TData>


### PR DESCRIPTION
This change avoids reallocating job native data when removing providers.