### PR TITLE
Actually schedule Burst-enabled jobs if job struct implements `IBurstUpdate*Job<>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 ## [Unreleased](https://github.com/gilzoide/unity-update-manager/compare/1.4.1...HEAD)
+### Added
+- `IBurstUpdateJob<>` and `IBurstUpdateTransformJob<>` interfaces to be used in place of `IUpdateJob` and `IUpdateTransformJob` when Burst compilation is desired.
+  Pass `BurstUpdateJob<...>` and `BurstUpdateTransformJob<...>` to their type parameters, so that Burst can compile the concrete job types.
+
+### Deprecated
+- `AJobBehaviour<,>`, `IJobUpdatable<,>` and `ITransformJobUpdatable<,>`.
+  Use the versions with a single type parameter instead.
+  Now that Burst support was moved to `IBurstUpdateJob<>` and `IBurstUpdateTransformJob<>`, specified at job struct definition, there is no need to specify the second parameter in job updatable types.
 
 
 ## [1.4.1](https://github.com/gilzoide/unity-update-manager/releases/tag/1.4.1)

--- a/Runtime/Extensions/TypeExtensions.cs
+++ b/Runtime/Extensions/TypeExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Gilzoide.UpdateManager.Jobs;
 
 namespace Gilzoide.UpdateManager.Extensions
@@ -13,6 +14,11 @@ namespace Gilzoide.UpdateManager.Extensions
         public static bool IsIUpdateTransformJob(this Type type)
         {
             return typeof(IUpdateTransformJob).IsAssignableFrom(type);
+        }
+
+        public static bool ImplementsGenericInterface(this Type type, Type interfaceType)
+        {
+            return type.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == interfaceType);
         }
     }
 }

--- a/Runtime/Jobs/AJobBehaviour.cs
+++ b/Runtime/Jobs/AJobBehaviour.cs
@@ -1,3 +1,4 @@
+using System;
 using Gilzoide.UpdateManager.Jobs.Internal;
 using UnityEngine;
 
@@ -76,8 +77,12 @@ namespace Gilzoide.UpdateManager.Jobs
 
     /// <summary>
     /// Alias for <see cref="AJobBehaviour{}"/>.
-    /// Pass <c>BurstUpdateTransformJob&lt;<typeparamref name="TData"/>&gt;</c> as <typeparamref name="TJob"/> to Burst compile your job.
     /// </summary>
+    /// <remarks>
+    ///   Deprecated: use <see cref="AJobBehaviour{}"/> instead and implement
+    ///   <see cref="IBurstUpdateTransformJob{}"/> in job definition to compile jobs with Burst.
+    /// </remarks>
+    [Obsolete("Use AJobBehaviour<> and implement IBurstUpdateTransformJob<> in job definition instead.")]
     public abstract class AJobBehaviour<TData, TJob> : AJobBehaviour<TData>
         where TData : struct, IUpdateTransformJob
         where TJob : struct, IInternalUpdateTransformJob<TData>

--- a/Runtime/Jobs/IJobUpdatable.cs
+++ b/Runtime/Jobs/IJobUpdatable.cs
@@ -1,3 +1,4 @@
+using System;
 using Gilzoide.UpdateManager.Jobs.Internal;
 
 namespace Gilzoide.UpdateManager.Jobs
@@ -12,8 +13,12 @@ namespace Gilzoide.UpdateManager.Jobs
 
     /// <summary>
     /// Alias for <see cref="IJobUpdatable{}"/>.
-    /// Pass <c>BurstUpdateJob&lt;<typeparamref name="TData"/>&gt;</c> as <typeparamref name="TJob"/> to Burst compile your job.
     /// </summary>
+    /// <remarks>
+    ///   Deprecated: use <see cref="IJobUpdatable{}"/> instead and implement
+    ///   <see cref="IBurstUpdateJob{}"/> in job definition to compile jobs with Burst.
+    /// </remarks>
+    [Obsolete("Use IJobUpdatable<> and implement IBurstUpdateJob<> in job definition instead.")]
     public interface IJobUpdatable<TData, TJob> : IJobUpdatable<TData>
         where TData : struct, IUpdateJob
         where TJob : struct, IInternalUpdateJob<TData>

--- a/Runtime/Jobs/ITransformJobUpdatable.cs
+++ b/Runtime/Jobs/ITransformJobUpdatable.cs
@@ -1,3 +1,4 @@
+using System;
 using Gilzoide.UpdateManager.Jobs.Internal;
 
 namespace Gilzoide.UpdateManager.Jobs
@@ -12,8 +13,12 @@ namespace Gilzoide.UpdateManager.Jobs
 
     /// <summary>
     /// Alias for <see cref="ITransformJobUpdatable{}"/>.
-    /// Pass <c>BurstUpdateTransformJob&lt;<typeparamref name="TData"/>&gt;</c> as <typeparamref name="TJob"/> to Burst compile your job.
     /// </summary>
+    /// <remarks>
+    ///   Deprecated: use <see cref="ITransformJobUpdatable{}"/> instead and implement
+    ///   <see cref="IBurstUpdateTransformJob{}"/> in job definition to compile jobs with Burst.
+    /// </remarks>
+    [Obsolete("Use ITransformJobUpdatable<> and implement IBurstUpdateTransformJob<> in job definition instead.")]
     public interface ITransformJobUpdatable<TData, TJob> : ITransformJobUpdatable<TData>
         where TData : struct, IUpdateTransformJob
         where TJob : struct, IInternalUpdateTransformJob<TData>

--- a/Runtime/Jobs/IUpdateJob.cs
+++ b/Runtime/Jobs/IUpdateJob.cs
@@ -1,3 +1,5 @@
+using Gilzoide.UpdateManager.Jobs.Internal;
+
 namespace Gilzoide.UpdateManager.Jobs
 {
     /// <summary>
@@ -6,5 +8,17 @@ namespace Gilzoide.UpdateManager.Jobs
     public interface IUpdateJob
     {
         void Execute();
+    }
+
+    /// <summary>
+    /// A Burst-enabled version of <see cref="IUpdateJob"/>.
+    /// Implement this if you want to have your job compiled by Burst.
+    /// </summary>
+    /// <typeparam name="TBurstJob">
+    ///   A concrete version of <see cref="BurstUpdateJob{}"/> using the job type itself as type parameter.
+    /// </typeparam>
+    public interface IBurstUpdateJob<TBurstJob> : IUpdateJob
+        where TBurstJob : IInternalBurstUpdateJob
+    {
     }
 }

--- a/Runtime/Jobs/IUpdateTransformJob.cs
+++ b/Runtime/Jobs/IUpdateTransformJob.cs
@@ -1,3 +1,4 @@
+using Gilzoide.UpdateManager.Jobs.Internal;
 using UnityEngine.Jobs;
 
 namespace Gilzoide.UpdateManager.Jobs
@@ -8,5 +9,17 @@ namespace Gilzoide.UpdateManager.Jobs
     public interface IUpdateTransformJob
     {
         void Execute(TransformAccess transform);
+    }
+
+    /// <summary>
+    /// A Burst-enabled version of <see cref="IUpdateTransformJob"/>.
+    /// Implement this if you want to have your job compiled by Burst.
+    /// </summary>
+    /// <typeparam name="TBurstJob">
+    ///   A concrete version of <see cref="BurstUpdateTransformJob{}"/> using the job type itself as type parameter.
+    /// </typeparam>
+    public interface IBurstUpdateTransformJob<TBurstJob> : IUpdateTransformJob
+        where TBurstJob : IInternalBurstUpdateTransformJob
+    {        
     }
 }

--- a/Runtime/Jobs/Internal/AUpdateJobManager.cs
+++ b/Runtime/Jobs/Internal/AUpdateJobManager.cs
@@ -33,6 +33,10 @@ namespace Gilzoide.UpdateManager.Jobs.Internal
 
         protected abstract JobHandle ScheduleJob(JobHandle dependsOn);
 
+#if HAVE_BURST
+        protected static readonly bool IsJobBurstCompiled = UpdateJobOptions.GetIsBurstCompiled<TData>();
+#endif
+
         private readonly IJobManager[] _dependencyManagers;
         private NativeArray<JobHandle> _dependencyJobHandles;
         private int _lastProcessedFrame;

--- a/Runtime/Jobs/Internal/IInternalUpdateJob.cs
+++ b/Runtime/Jobs/Internal/IInternalUpdateJob.cs
@@ -7,4 +7,8 @@ namespace Gilzoide.UpdateManager.Jobs.Internal
     {
         UnsafeNativeList<TData> Data { set; }
     }
+
+    public interface IInternalBurstUpdateJob
+    {
+    }
 }

--- a/Runtime/Jobs/Internal/IInternalUpdateTransformJob.cs
+++ b/Runtime/Jobs/Internal/IInternalUpdateTransformJob.cs
@@ -7,4 +7,8 @@ namespace Gilzoide.UpdateManager.Jobs.Internal
     {
         UnsafeNativeList<TData> Data { set; }
     }
+
+    public interface IInternalBurstUpdateTransformJob
+    {
+    }
 }

--- a/Runtime/Jobs/Internal/UpdateJobOptions.cs
+++ b/Runtime/Jobs/Internal/UpdateJobOptions.cs
@@ -83,7 +83,8 @@ namespace Gilzoide.UpdateManager.Jobs.Internal
 #if HAVE_BURST
         public static bool GetIsBurstCompiled<TData>()
         {
-            return typeof(TData).GetCustomAttribute<Unity.Burst.BurstCompileAttribute>() != null;
+            return typeof(TData).ImplementsGenericInterface(typeof(IBurstUpdateJob<>))
+                || typeof(TData).ImplementsGenericInterface(typeof(IBurstUpdateTransformJob<>));
         }
 #endif
     }

--- a/Runtime/Jobs/Internal/UpdateJobOptions.cs
+++ b/Runtime/Jobs/Internal/UpdateJobOptions.cs
@@ -79,5 +79,12 @@ namespace Gilzoide.UpdateManager.Jobs.Internal
             }
             return managers;
         }
+
+#if HAVE_BURST
+        public static bool GetIsBurstCompiled<TData>()
+        {
+            return typeof(TData).GetCustomAttribute<Unity.Burst.BurstCompileAttribute>() != null;
+        }
+#endif
     }
 }

--- a/Runtime/Jobs/UpdateJob.cs
+++ b/Runtime/Jobs/UpdateJob.cs
@@ -16,7 +16,7 @@ namespace Gilzoide.UpdateManager.Jobs
 #if HAVE_BURST
     [Unity.Burst.BurstCompile]
 #endif
-    public struct BurstUpdateJob<TData> : IInternalUpdateJob<TData>
+    public struct BurstUpdateJob<TData> : IInternalUpdateJob<TData>, IInternalBurstUpdateJob
         where TData : struct, IUpdateJob
     {
         public UnsafeNativeList<TData> Data { get; set; }

--- a/Runtime/Jobs/UpdateTransformJob.cs
+++ b/Runtime/Jobs/UpdateTransformJob.cs
@@ -17,7 +17,7 @@ namespace Gilzoide.UpdateManager.Jobs
 #if HAVE_BURST
     [Unity.Burst.BurstCompile]
 #endif
-    public struct BurstUpdateTransformJob<TData> : IInternalUpdateTransformJob<TData>
+    public struct BurstUpdateTransformJob<TData> : IInternalUpdateTransformJob<TData>, IInternalBurstUpdateTransformJob
         where TData : struct, IUpdateTransformJob
     {
         public UnsafeNativeList<TData> Data { get; set; }

--- a/Runtime/Jobs/UpdateTransformJobManager.cs
+++ b/Runtime/Jobs/UpdateTransformJobManager.cs
@@ -29,25 +29,25 @@ namespace Gilzoide.UpdateManager.Jobs
 #if HAVE_BURST
             if (IsJobBurstCompiled)
             {
-                var job = new BurstUpdateTransformJob<TData>
-                {
-                    Data = _jobData.Data,
-                };
-                return ReadOnlyTransformAccess
-                    ? job.ScheduleReadOnly(_jobData.Transforms, JobBatchSize, dependsOn)
-                    : job.Schedule(_jobData.Transforms, dependsOn);
+                return Schedule<BurstUpdateTransformJob<TData>>(dependsOn);
             }
             else
 #endif
             {
-                var job = new UpdateTransformJob<TData>
-                {
-                    Data = _jobData.Data,
-                };
-                return ReadOnlyTransformAccess
-                    ? job.ScheduleReadOnly(_jobData.Transforms, JobBatchSize, dependsOn)
-                    : job.Schedule(_jobData.Transforms, dependsOn);
+                return Schedule<UpdateTransformJob<TData>>(dependsOn);
             }
+        }
+
+        protected JobHandle Schedule<TJob>(JobHandle dependsOn)
+            where TJob : struct, IInternalUpdateTransformJob<TData>
+        {
+            var job = new TJob
+            {
+                Data = _jobData.Data,
+            };
+            return ReadOnlyTransformAccess
+                ? job.ScheduleReadOnly(_jobData.Transforms, JobBatchSize, dependsOn)
+                : job.Schedule(_jobData.Transforms, dependsOn);
         }
     }
 }

--- a/Samples~/FollowTarget/FollowTarget.cs
+++ b/Samples~/FollowTarget/FollowTarget.cs
@@ -5,11 +5,8 @@ using UnityEngine.Jobs;
 
 namespace Gilzoide.UpdateManager.Sample.FollowTarget
 {
-#if HAVE_BURST
-    [Unity.Burst.BurstCompile]
-#endif
     [DependsOn(typeof(TargetJob))]
-    public struct FollowTargetJob : IUpdateTransformJob
+    public struct FollowTargetJob : IBurstUpdateTransformJob<BurstUpdateTransformJob<FollowTargetJob>>
     {
         [ReadOnly] public NativeReference<Vector3> TargetPositionReference;
         public float Speed;
@@ -26,7 +23,7 @@ namespace Gilzoide.UpdateManager.Sample.FollowTarget
         }
     }
 
-    public class FollowTarget : AJobBehaviour<FollowTargetJob, BurstUpdateTransformJob<FollowTargetJob>>,
+    public class FollowTarget : AJobBehaviour<FollowTargetJob>,
         IJobDataSynchronizer<FollowTargetJob>
     {
         [SerializeField] private Target target;

--- a/Samples~/FollowTarget/FollowTarget.cs
+++ b/Samples~/FollowTarget/FollowTarget.cs
@@ -5,6 +5,9 @@ using UnityEngine.Jobs;
 
 namespace Gilzoide.UpdateManager.Sample.FollowTarget
 {
+#if HAVE_BURST
+    [Unity.Burst.BurstCompile]
+#endif
     [DependsOn(typeof(TargetJob))]
     public struct FollowTargetJob : IUpdateTransformJob
     {

--- a/Samples~/FollowTarget/Target.cs
+++ b/Samples~/FollowTarget/Target.cs
@@ -5,11 +5,8 @@ using UnityEngine.Jobs;
 
 namespace Gilzoide.UpdateManager.Sample.FollowTarget
 {
-#if HAVE_BURST
-    [Unity.Burst.BurstCompile]
-#endif
     [ReadOnlyTransformAccess]
-    public struct TargetJob : IUpdateTransformJob
+    public struct TargetJob : IBurstUpdateTransformJob<BurstUpdateTransformJob<TargetJob>>
     {
         [WriteOnly] public NativeReference<Vector3> PositionReference;
 
@@ -19,7 +16,7 @@ namespace Gilzoide.UpdateManager.Sample.FollowTarget
         }
     }
 
-    public class Target : AJobBehaviour<TargetJob, BurstUpdateTransformJob<TargetJob>>
+    public class Target : AJobBehaviour<TargetJob>
     {
         public NativeReference<Vector3> PositionReference => positionReference;
         private NativeReference<Vector3> positionReference;

--- a/Samples~/FollowTarget/Target.cs
+++ b/Samples~/FollowTarget/Target.cs
@@ -5,6 +5,9 @@ using UnityEngine.Jobs;
 
 namespace Gilzoide.UpdateManager.Sample.FollowTarget
 {
+#if HAVE_BURST
+    [Unity.Burst.BurstCompile]
+#endif
     [ReadOnlyTransformAccess]
     public struct TargetJob : IUpdateTransformJob
     {


### PR DESCRIPTION
Fixes #15, but requires ~~manually specifying `[BurstCompile]` attribute to the user-defined `IUpdateJob` or `IUpdateTransformJob`~~ implementing `IBurstUpdateJob<>`/`IBurstUpdateTransformJob<>` instead of `IUpdateJob`/`IUpdateTransformJob` in job struct definitions.